### PR TITLE
added shallow conversion for query to ast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
-
+pom.xml 
+target

--- a/test/edn_query_language/core_test.clj
+++ b/test/edn_query_language/core_test.clj
@@ -287,3 +287,17 @@
 (deftest test-query-id
   (is (= (eql/query-id '[:a :b {[:join "val"] [{(:c {:page 10}) [:d]}]}])
          -61421281)))
+
+
+(deftest shallow-conversion
+  (testing "requesting shallow conversion will only convert the first layer of a query"
+    (let [ast (eql/query->shallow-ast [:x
+                                       {:y [{:z [:a]}]}
+                                       {[:table 1] [:z {:other [:m :n]}]}
+                                       {:ujoin {:u1 [:x] :u2 [:y]}}])]
+      (is (= {:type     :root,
+              :children [{:type :prop, :dispatch-key :x, :key :x}
+                         {:type :join, :dispatch-key :y, :key :y, :query [{:z [:a]}]}
+                         {:type :join, :dispatch-key :table, :key [:table 1], :query [:z {:other [:m :n]}]}
+                         {:type :join, :dispatch-key :ujoin, :key :ujoin, :query {:u1 [:x], :u2 [:y]}}]}
+            ast)))))


### PR DESCRIPTION
Fulcro 3 needs to look at root props to detect shared prop changes, but doing so against the full AST is expensive.  I added the ability to tell query->ast to not follow joins.