### PR TITLE
Add variadic option for merge-asts and merge-queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Not yet released
+- Add variadic versions of `merge-ast` and `merge-queries`
+
 ## [2021.07.18]
 - `merge-ast` support arities 0 and 1 to work as a reducing function
 

--- a/src/edn_query_language/core.cljc
+++ b/src/edn_query_language/core.cljc
@@ -398,7 +398,7 @@
    (reduce (fn [ast q] (merge-asts ast q)) (merge-asts qa qb) more)))
 
 (defn merge-queries
-  "Merges two queries"
+  "Merges two or more queries"
   ([qa] qa)
   ([qa qb]
    (some-> (merge-asts (query->ast qa) (query->ast qb))

--- a/src/edn_query_language/core.cljc
+++ b/src/edn_query_language/core.cljc
@@ -393,13 +393,20 @@
                 :else ast)
               (update ast :children conj item-b)))
     qa
-    (:children qb))))
+    (:children qb)))
+  ([qa qb & more]
+   (reduce (fn [ast q] (merge-asts ast q)) (merge-asts qa qb) more)))
 
 (defn merge-queries
   "Merges two queries"
-  [qa qb]
-  (some-> (merge-asts (query->ast qa) (query->ast qb))
-    (ast->query)))
+  ([qa] qa)
+  ([qa qb]
+   (some-> (merge-asts (query->ast qa) (query->ast qb))
+           (ast->query)))
+  ([qa qb & more]
+   (some-> (reduce (fn [ast q] (merge-asts ast (query->ast q)))
+                   (merge-asts (query->ast qa) (query->ast qb)) more)
+           (ast->query))))
 
 (defn mask-query* [{:keys [children] :as source-ast} mask-ast]
   (reduce
@@ -515,5 +522,5 @@
     :ret (s/nilable :edn-query-language.ast/node))
 
   (s/fdef merge-queries
-    :args (s/cat :qa (s/nilable ::query), :qb (s/nilable ::query))
+    :args (s/cat :qa (s/nilable ::query), :qb (s/nilable ::query), :more (s/* (s/nilable ::query)))
     :ret (s/nilable ::query)))

--- a/test/edn_query_language/core_test.cljc
+++ b/test/edn_query_language/core_test.cljc
@@ -254,6 +254,9 @@
   (is (= (eql/merge-queries [{:user [:name]}] [{:user [:email]}] [{:user [:photo]}])
          [{:user [:name :email :photo]}]))
 
+  (is (= (eql/merge-queries [:a] nil [:c] nil [:e] nil)
+         [:a :c :e]))
+
   (testing "don't merge queries with different params"
     (is (= (eql/merge-queries ['({:user [:name]} {:login "u1"})]
              ['({:user [:email]} {:login "u2"})])

--- a/test/edn_query_language/core_test.cljc
+++ b/test/edn_query_language/core_test.cljc
@@ -248,6 +248,12 @@
   (is (= (eql/merge-queries [{:a [:x]}] [:a])
          [{:a [:x]}]))
 
+  (is (= (eql/merge-queries [:a] [:b] [:c :d])
+         [:a :b :c :d]))
+
+  (is (= (eql/merge-queries [{:user [:name]}] [{:user [:email]}] [{:user [:photo]}])
+         [{:user [:name :email :photo]}]))
+
   (testing "don't merge queries with different params"
     (is (= (eql/merge-queries ['({:user [:name]} {:login "u1"})]
              ['({:user [:email]} {:login "u2"})])


### PR DESCRIPTION
I was going to write a variadic 'merge-queries' function in my own library, as I have need to merge the queries from multiple components. However, on reflection, I thought it might be best to instead implement this upstream. It is a minor, and non-breaking change, and I have added two trivial tests as well, but the code is fairly trivial and hopefully not contentious. 

Would you consider accepting this?

Best wishes,

Mark