### PR TITLE
Fix spec for merge-variadic args

### DIFF
--- a/src/edn_query_language/core.cljc
+++ b/src/edn_query_language/core.cljc
@@ -518,7 +518,9 @@
     :args (s/or
             :init (s/cat)
             :completion (s/cat :q :edn-query-language.ast/node)
-            :step (s/cat :qa :edn-query-language.ast/node, :qb :edn-query-language.ast/node))
+            :step (s/cat :qa :edn-query-language.ast/node
+                         :qb :edn-query-language.ast/node
+                         :more (s/* :edn-query-language.ast/node)))
     :ret (s/nilable :edn-query-language.ast/node))
 
   (s/fdef merge-queries

--- a/test/edn_query_language/core_test.cljc
+++ b/test/edn_query_language/core_test.cljc
@@ -388,7 +388,14 @@
                         :key          :b
                         :type         :prop}]
             :type     :root}
-          (transduce (map identity)
-            eql/merge-asts
-            [(eql/query->ast [:a])
-             (eql/query->ast [:b])])))))
+           (transduce (map identity)
+                      eql/merge-asts
+                      [(eql/query->ast [:a])
+                       (eql/query->ast [:b])]))))
+  (testing
+    "variadic"
+    (is (= (eql/ast->query
+             (eql/merge-asts (eql/query->ast [:a])
+                             (eql/query->ast [:b])
+                             (eql/query->ast [:c])))
+           [:a :b :c]))))


### PR DESCRIPTION
The addition of variadic args to `merge-asts` and `merge-queries` did not correctly update the function spec for `merge-asts`. This adds a test to catch this and fixes the specification. 